### PR TITLE
client: Add a ClientPool

### DIFF
--- a/core/client/client_options.go
+++ b/core/client/client_options.go
@@ -15,6 +15,14 @@ type config struct {
 	extraClientOptions []connect.ClientOption
 }
 
+func configFromOptions(opts ...Option) *config {
+	cfg := &config{}
+	for _, o := range opts {
+		o(cfg)
+	}
+	return cfg
+}
+
 type Option func(*config)
 
 func WithTLSConfig(cfg *tls.Config) Option {

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/bufbuild/connect-go"
+
+	"github.com/planetscale/psdb/auth"
+	psdbclient "github.com/planetscale/psdb/core/client"
+	psdbv1alpha1 "github.com/planetscale/psdb/types/psdb/v1alpha1"
+	"github.com/planetscale/psdb/types/psdb/v1alpha1/psdbv1alpha1connect"
+)
+
+var (
+	flagAddr     = flag.String("addr", "127.0.0.1:8080", "rpc address to test")
+	flagTLSCa    = flag.String("tls-ca", "testcerts/ca-cert.pem", "")
+	flagUser     = flag.String("u", "xxxxxxxxxx", "")
+	flagPassword = flag.String("p", "bar", "")
+)
+
+func main() {
+	flag.Parse()
+
+	tlsConfig := psdbclient.DefaultTLSConfig()
+	if *flagTLSCa != "" {
+		var err error
+		tlsConfig, err = psdbclient.TLSConfigWithRoot(*flagTLSCa)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	opts := []psdbclient.Option{
+		psdbclient.WithTLSConfig(tlsConfig),
+	}
+
+	client := psdbclient.New(
+		*flagAddr,
+		psdbv1alpha1connect.NewDatabaseClient,
+		auth.NewBasicAuth(*flagUser, *flagPassword),
+		opts...,
+	)
+	fmt.Println(client)
+
+	fmt.Println(client.CreateSession(context.Background(), connect.NewRequest(&psdbv1alpha1.CreateSessionRequest{})))
+
+	pool := psdbclient.NewUnauthenticatedPool(
+		psdbv1alpha1connect.NewDatabaseClient,
+		opts...,
+	)
+
+	client = pool.Get(*flagAddr)
+	fmt.Println(client, pool.Get(*flagAddr))
+	fmt.Println(client.CreateSession(context.Background(), connect.NewRequest(&psdbv1alpha1.CreateSessionRequest{})))
+	fmt.Println(pool.Len())
+}


### PR DESCRIPTION
ClientPool generates a new Client struct per unique hostname.

ClientPool doesn't clean up after itself, so the pool will infinitely
grow unless externally managed.