### PR TITLE
Optimize Parse function

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -146,6 +146,42 @@ func TestParseWithSecret(t *testing.T) {
 	}
 }
 
+func BenchmarkParse(b *testing.B) {
+	cases := []struct {
+		name, in string
+	}{
+		{"Basic", "Basic eHh4eHh4eHh4eHJvdXRlLWhpbnQ6YmFy"},
+		{"mysql-sha1", "mysql-sha1 eHh4eHh4eHh4eHJvdXRlLWhpbnQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+		{"mysql-sha256", "mysql-sha256 eHh4eHh4eHh4eHJvdXRlLWhpbnQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				Parse(c.in)
+			}
+		})
+	}
+}
+
+func BenchmarkParseWithSecret(b *testing.B) {
+	cases := []struct {
+		name, in string
+	}{
+		{"Basic", "Basic eHh4eHh4eHh4eHJvdXRlLWhpbnQ6YmFy"},
+		{"mysql-sha1", "mysql-sha1 eHh4eHh4eHh4eHJvdXRlLWhpbnQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+		{"mysql-sha256", "mysql-sha256 eHh4eHh4eHh4eHJvdXRlLWhpbnQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				ParseWithSecret(c.in)
+			}
+		})
+	}
+}
+
 func joinBytes(a []byte, rest ...[]byte) []byte {
 	ll := len(a)
 	for _, b := range rest {


### PR DESCRIPTION
This unsafe []byte -> string converstion removes the only needless allocation.

This is safe to do in this context since we are not modifying the underlying byte buffer, and it's allocated already for this base64 decoding. So it's needless to do another copy to allocate another string.

```
$ benchstat {before,after}.txt
goos: darwin
goarch: arm64
pkg: github.com/planetscale/psdb/auth
                                │ before.txt  │              after.txt              │
                                │   sec/op    │   sec/op     vs base                │
Parse/Basic-10                    79.17n ± 1%   65.91n ± 2%  -16.74% (p=0.000 n=10)
Parse/mysql-sha1-10               95.91n ± 1%   80.83n ± 1%  -15.73% (p=0.000 n=10)
Parse/mysql-sha256-10             96.01n ± 1%   80.64n ± 1%  -16.01% (p=0.000 n=10)
ParseWithSecret/Basic-10          79.55n ± 1%   66.42n ± 0%  -16.49% (p=0.000 n=10)
ParseWithSecret/mysql-sha1-10     96.73n ± 1%   79.63n ± 1%  -17.67% (p=0.000 n=10)
ParseWithSecret/mysql-sha256-10   96.17n ± 2%   80.06n ± 0%  -16.75% (p=0.000 n=10)
geomean                           90.22n        75.27n       -16.57%

                                │ before.txt │             after.txt              │
                                │    B/op    │    B/op     vs base                │
Parse/Basic-10                    128.0 ± 0%   104.0 ± 0%  -18.75% (p=0.000 n=10)
Parse/mysql-sha1-10               152.0 ± 0%   128.0 ± 0%  -15.79% (p=0.000 n=10)
Parse/mysql-sha256-10             152.0 ± 0%   128.0 ± 0%  -15.79% (p=0.000 n=10)
ParseWithSecret/Basic-10          128.0 ± 0%   104.0 ± 0%  -18.75% (p=0.000 n=10)
ParseWithSecret/mysql-sha1-10     152.0 ± 0%   128.0 ± 0%  -15.79% (p=0.000 n=10)
ParseWithSecret/mysql-sha256-10   152.0 ± 0%   128.0 ± 0%  -15.79% (p=0.000 n=10)
geomean                           143.5        119.4       -16.79%

                                │ before.txt │             after.txt              │
                                │ allocs/op  │ allocs/op   vs base                │
Parse/Basic-10                    3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
Parse/mysql-sha1-10               3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
Parse/mysql-sha256-10             3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
ParseWithSecret/Basic-10          3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
ParseWithSecret/mysql-sha1-10     3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
ParseWithSecret/mysql-sha256-10   3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
geomean                           3.000        2.000       -33.33%
```

I thought there'd be more I can squeeze out of here, but I don't think anything else is worth it.