### PR TITLE
security: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: setup go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '^1.21'
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>planetscale/renovate-config',
+  ],
+}


### PR DESCRIPTION
Pins all GitHub Actions workflow steps to immutable commit SHAs instead of mutable tags, following supply chain security best practices.

Changes:
- All `uses: action@tag` refs updated to latest versions and pinned to SHAs
- Added renovate.json5 extending planetscale/renovate-config so felix keeps these pinned and up-to-date going forward